### PR TITLE
Don't focus elements with negative tab index

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ export const EnterToTabMixin = {
           && !target.preventEnterTab) {
         e.preventDefault();
         const allElementsQuery = this.$el.querySelectorAll('input, button, a, textarea, select, audio, video, [contenteditable]');
-        const allElements = [...allElementsQuery].filter(r => !r.disabled && !r.hidden && r.offsetParent && !r.readOnly);
+        const allElements = [...allElementsQuery].filter(r => !r.disabled && !r.hidden && r.offsetParent && !r.readOnly && r.tabIndex >= 0);
         const currentIndex = [...allElements].indexOf(target);
         const targetIndex = (currentIndex + 1) % allElements.length;
         allElements[targetIndex].focus();


### PR DESCRIPTION
As per https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex

> A negative value (usually tabindex="-1") means that the element is not reachable via sequential keyboard navigation, but could be focused with JavaScript or visually by clicking with the mouse. It's mostly useful to create accessible widgets with JavaScript. 

Thanks for your mixin, it's really helpful for me!